### PR TITLE
Fix for `cannot read type 'reset'` error on TransactButton

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -780,6 +780,7 @@ export class Bond {
 	 * of `Bond` may be available.
 	 */
 	static instanceOf(b) {
+		if (b === null) {return 'undefined'};
 		return typeof(b) === 'object' && b !== null && typeof(b.reset) === 'function' && typeof(b.changed) === 'function';
 	}
 }


### PR DESCRIPTION
Just added a check for null that fixes the error TransactButton was throwing