### PR TITLE
fixed tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -95,14 +95,20 @@ describe('Bond', function () {
 	});
 
 	it('should use cache', () => {
-		let t = new Bond(true, 'myNumber');
+		const cacheConfig = {
+			id: 'myNumber',
+			stringify: JSON.stringify,
+			parse: JSON.parse
+		};
+
+		let t = new Bond(true, cacheConfig);
 		var x = 0;
 		let a = t.tie(_ => { x = _; });
 
 		t.trigger(42);
 		x.should.equal(42);
 
-		let u = new Bond(true, 'myNumber');
+		let u = new Bond(true, cacheConfig);
 		var y = 0;
 		let b = u.tie(_ => { y = _; });
 
@@ -117,14 +123,20 @@ describe('Bond', function () {
 	});
 
 	it('should switch cache master as necessary', () => {
-		let t = new Bond(true, 'myNumber');
+		const cacheConfig = {
+			id: 'myNumberTwo',
+			stringify: JSON.stringify,
+			parse: JSON.parse
+		};
+
+		let t = new Bond(true, cacheConfig);
 		var x = 0;
 		let a = t.tie(_ => { x = _; });
 
 		t.trigger(42);
 		x.should.equal(42);
 
-		let u = new Bond(true, 'myNumber');
+		let u = new Bond(true, cacheConfig);
 		var y = 0;
 		let b = u.tie(_ => { y = _; });
 
@@ -134,7 +146,7 @@ describe('Bond', function () {
 		x.should.equal(69);
 		y.should.equal(69);
 
-		let v = new Bond(true, 'myNumber');
+		let v = new Bond(true, cacheConfig);
 		var z = 0;
 		let c = v.tie(_ => { z = _; });
 

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -63,7 +63,12 @@ describe('BondCache', function () {
 		let fireBonds = {};
 		class FireBond extends Bond {
 			constructor (uuid) {
-				super(true, uuid);
+				const cacheConfig = {
+					id: uuid,
+					stringify: JSON.stringify,
+					parse: JSON.parse
+				};
+				super(true, cacheConfig);
 			}
 			initialise () {
 				if (typeof fireBonds[this._uuid] === 'undefined') {

--- a/test/ipc.js
+++ b/test/ipc.js
@@ -105,10 +105,8 @@ describe('BondCache', function () {
 			let x = 0;
 			let xt = childBond.tie(n => x = n);
 
-			console.log('Scene mQ', scene.messageQueue);
 			scene.play();
 
-			console.log('fireBonds', fireBonds);
 			fireBonds['test/fireInstance'].length.should.equal(1);
 			fireBonds['test/fireInstance'][0].should.equal(fireInstance);
 
@@ -116,7 +114,6 @@ describe('BondCache', function () {
 			FireBond.fire('test/fireInstance', 69);
 			fireInstance._value.should.equal(69);
 
-			console.log('Scene mQ', scene.messageQueue);
 			x.should.equal(0);
 
 			scene.play();


### PR DESCRIPTION
Updated the bond's caches to be initialised with an object instead of a string/id in the test scripts: new Bond(true, {id: 'myNumber',stringify: JSON.stringify,parse: JSON.parse}) since some tests were failing, now everything passes but I was wondering in which cases we would need a custom stringify function? wouldnt it be better to just default to JSON.stringify/parse (but allow custom functions through an object)? 