### PR TITLE
Fix: convert Uint8Array to Buffer before sending it to bs58.encode in oo7-substrate

### DIFF
--- a/packages/oo7-substrate/src/ss58.js
+++ b/packages/oo7-substrate/src/ss58.js
@@ -40,7 +40,7 @@ function ss58Encode(a, type = defaultType, checksumLength = null, length = null,
 	}
 	let hash = blake2b((type & 1) ? accountId : new Uint8Array([type, ...payload]))
 	let complete = new Uint8Array([type, ...payload, ...hash.slice(0, checksumLength)])
-	return bs58.encode(complete)
+	return bs58.encode(Buffer.from(complete))
 }
 
 /// `lookupIndex` must be synchronous. If you can do that, then throw, catch outside the


### PR DESCRIPTION
base-x 3.0.5 encode doesn't accept a Uint8Array throwing a typeError