### PR TITLE
Fixes for oo7-substrate to work in nodejs

### DIFF
--- a/packages/oo7-substrate/src/codec.js
+++ b/packages/oo7-substrate/src/codec.js
@@ -2,7 +2,7 @@ const { TextDecoder } = require('text-encoding')
 const { ss58Decode } = require('./ss58')
 const { VecU8, AccountId, Hash, VoteThreshold, SlashPreference, Moment, Balance,
 	BlockNumber, AccountIndex, Tuple, TransactionEra, Perbill, Permill } = require('./types')
-const { toLE, leToNumber, leToSigned, bytesToHex } = require('./utils')
+const { toLE, leToNumber, leToSigned, bytesToHex, hexToBytes } = require('./utils')
 const { metadata } = require('./metadata')
 
 const transforms = {

--- a/packages/oo7-substrate/src/index.js
+++ b/packages/oo7-substrate/src/index.js
@@ -31,8 +31,6 @@ function tallyAmounts(x) {
 if (typeof window !== 'undefined') {
 	window.ss58Encode = ss58Encode
 	window.ss58Decode = ss58Decode
-	window.ss58Encode = ss58Encode
-	window.ss58Decode = ss58Decode
 	window.bytesToHex = bytesToHex
 	window.stringToBytes = stringToBytes
 	window.hexToBytes = hexToBytes

--- a/packages/oo7-substrate/src/secretStore.js
+++ b/packages/oo7-substrate/src/secretStore.js
@@ -17,8 +17,9 @@ function seedFromPhrase(phrase) {
 }
 
 class SecretStore extends Bond {
-	constructor () {
+	constructor (storage) {
 		super()
+		this._storage = storage || typeof localStorage === 'undefined' ? {} : localStorage
 		this._keys = []
 		this._load()
 	}
@@ -38,7 +39,7 @@ class SecretStore extends Bond {
 	}
 
 	find (identifier) {
-		if (this._keys.indexOf(identifier) !== -1) { 
+		if (this._keys.indexOf(identifier) !== -1) {
 			return identifier
 		}
 		if (identifier instanceof Uint8Array && identifier.length == 32 || identifier instanceof AccountId) {
@@ -72,10 +73,10 @@ class SecretStore extends Bond {
 	}
 
 	_load () {
-		if (localStorage.secretStore) {
-			this._keys = JSON.parse(localStorage.secretStore).map(({seed, phrase, name}) => ({ phrase, name, seed: hexToBytes(seed) }))
-		} else if (localStorage.secretStore2) {
-			this._keys = JSON.parse(localStorage.secretStore2).map(({seed, name}) => ({ phrase: seed, name }))
+		if (this._storage.secretStore) {
+			this._keys = JSON.parse(this._storage.secretStore).map(({seed, phrase, name}) => ({ phrase, name, seed: hexToBytes(seed) }))
+		} else if (this._storage.secretStore2) {
+			this._keys = JSON.parse(this._storage.secretStore2).map(({seed, name}) => ({ phrase: seed, name }))
 		} else {
 			this._keys = [{
 				name: 'Default',
@@ -100,16 +101,16 @@ class SecretStore extends Bond {
 		})
 		this._byAddress = byAddress
 		this._byName = byName
-		localStorage.secretStore = JSON.stringify(this._keys.map(k => ({seed: bytesToHex(k.seed), phrase: k.phrase, name: k.name})))
+		this._storage.secretStore = JSON.stringify(this._keys.map(k => ({seed: bytesToHex(k.seed), phrase: k.phrase, name: k.name})))
 		this.trigger({keys: this._keys, byAddress: this._byAddress, byName: this._byName})
 	}
 }
 
 let s_secretStore = null;
 
-function secretStore() {
+function secretStore(storage) {
 	if (s_secretStore === null) {
-		s_secretStore = new SecretStore;
+		s_secretStore = new SecretStore(storage);
 	}
 	return s_secretStore;
 }

--- a/packages/oo7-substrate/src/ss58.js
+++ b/packages/oo7-substrate/src/ss58.js
@@ -1,7 +1,7 @@
 const bs58 = require('bs58')
 const { blake2b } = require('blakejs')
 const { toLE, leToNumber } = require('./utils')
-const { AccountIndex } = require('./types')
+const { AccountIndex, AccountId } = require('./types')
 
 let defaultType = 42
 const KNOWN_TYPES = [0, 1, 42, 43, 68, 69]

--- a/packages/oo7-substrate/src/transact.js
+++ b/packages/oo7-substrate/src/transact.js
@@ -5,6 +5,7 @@ const { encode } = require('./codec')
 const { secretStore } = require('./secretStore')
 const { TransactionEra, AccountIndex } = require('./types')
 const { runtimeUp, runtime, chain } = require('./bonds')
+const { bytesToHex } = require('./utils')
 
 class TransactionBond extends SubscriptionBond {
 	constructor (data) {

--- a/packages/oo7-substrate/src/types.js
+++ b/packages/oo7-substrate/src/types.js
@@ -1,21 +1,3 @@
-function toLE(val, bytes) {
-	let flip = false;
-	if (val < 0) {
-		val = -val - 1;
-		flip = true;
-	}
-
-	let r = new VecU8(bytes);
-	for (var o = 0; o < bytes; ++o) {
-		r[o] = val % 256;
-		if (flip) {
-			r[o] = ~r[o] & 0xff;
-		}
-		val /= 256;
-	}
-	return r;
-}
-
 class VecU8 extends Uint8Array {
 	toJSON() {
 		return { _type: 'VecU8', data: Array.from(this) }
@@ -127,4 +109,4 @@ function reviver(key, bland) {
 }
 
 module.exports = { VecU8, AccountId, Hash, VoteThreshold, SlashPreference, Moment, Balance,
-	BlockNumber, AccountIndex, Tuple, TransactionEra, Perbill, Permill, reviver, toLE }
+	BlockNumber, AccountIndex, Tuple, TransactionEra, Perbill, Permill, reviver }

--- a/packages/oo7-substrate/src/types.js
+++ b/packages/oo7-substrate/src/types.js
@@ -1,3 +1,20 @@
+function toLE(val, bytes) {
+	let flip = false;
+	if (val < 0) {
+		val = -val - 1;
+		flip = true;
+	}
+
+	let r = new VecU8(bytes);
+	for (var o = 0; o < bytes; ++o) {
+		r[o] = val % 256;
+		if (flip) {
+			r[o] = ~r[o] & 0xff;
+		}
+		val /= 256;
+	}
+	return r;
+}
 
 class VecU8 extends Uint8Array {
 	toJSON() {
@@ -110,4 +127,4 @@ function reviver(key, bland) {
 }
 
 module.exports = { VecU8, AccountId, Hash, VoteThreshold, SlashPreference, Moment, Balance,
-	BlockNumber, AccountIndex, Tuple, TransactionEra, Perbill, Permill, reviver }
+	BlockNumber, AccountIndex, Tuple, TransactionEra, Perbill, Permill, reviver, toLE }

--- a/packages/oo7-substrate/src/types.js
+++ b/packages/oo7-substrate/src/types.js
@@ -1,3 +1,5 @@
+const { toLE } = require('./utils')
+
 class VecU8 extends Uint8Array {
 	toJSON() {
 		return { _type: 'VecU8', data: Array.from(this) }

--- a/packages/oo7-substrate/src/utils.js
+++ b/packages/oo7-substrate/src/utils.js
@@ -1,10 +1,8 @@
-const { VecU8, toLE } = require('./types')
-
 function stringToSeed(s) {
 	if (s.match(/^0x[0-9a-fA-F]{64}$/)) {
-		return new VecU8(hexToBytes(s))
+		return hexToBytes(s)
 	}
-	var data = new VecU8(32);
+	var data = new Uint8Array(32);
 	data.fill(32);
 	for (var i = 0; i < s.length; i++){
 		data[i] = s.charCodeAt(i);
@@ -12,7 +10,7 @@ function stringToSeed(s) {
 	return data;
 }
 function stringToBytes(s) {
-	var data = new VecU8(s.length);
+	var data = new Uint8Array(s.length);
 	for (var i = 0; i < s.length; i++){
 		data[i] = s.charCodeAt(i);
 	}
@@ -20,14 +18,14 @@ function stringToBytes(s) {
 }
 function hexToBytes(str) {
 	if (!str) {
-		return new VecU8();
+		return new Uint8Array();
 	}
 	var a = [];
 	for (var i = str.startsWith('0x') ? 2 : 0, len = str.length; i < len; i += 2) {
 		a.push(parseInt(str.substr(i, 2), 16));
 	}
 
-	return new VecU8(a);
+	return new Uint8Array(a);
 }
 function bytesToHex(uint8arr) {
 	if (!uint8arr) {
@@ -56,6 +54,24 @@ function leHexToNumber(le) {
 		be = le.substr(i, 2) + be;
 	}
 	return Number.parseInt(be, 16);
+}
+
+function toLE(val, bytes) {
+	let flip = false;
+	if (val < 0) {
+		val = -val - 1;
+		flip = true;
+	}
+
+	let r = new Uint8Array(bytes);
+	for (var o = 0; o < bytes; ++o) {
+		r[o] = val % 256;
+		if (flip) {
+			r[o] = ~r[o] & 0xff;
+		}
+		val /= 256;
+	}
+	return r;
 }
 
 function leToNumber(le) {

--- a/packages/oo7-substrate/src/utils.js
+++ b/packages/oo7-substrate/src/utils.js
@@ -1,4 +1,4 @@
-const { VecU8 } = require('./types')
+const { VecU8, toLE } = require('./types')
 
 function stringToSeed(s) {
 	if (s.match(/^0x[0-9a-fA-F]{64}$/)) {
@@ -56,24 +56,6 @@ function leHexToNumber(le) {
 		be = le.substr(i, 2) + be;
 	}
 	return Number.parseInt(be, 16);
-}
-
-function toLE(val, bytes) {
-	let flip = false;
-	if (val < 0) {
-		val = -val - 1;
-		flip = true;
-	}
-
-	let r = new VecU8(bytes);
-	for (var o = 0; o < bytes; ++o) {
-		r[o] = val % 256;
-		if (flip) {
-			r[o] = ~r[o] & 0xff;
-		}
-		val /= 256;
-	}
-	return r;
 }
 
 function leToNumber(le) {


### PR DESCRIPTION
While trying to work with oo7-substrate in a command line project had to fix a few issues:

- Add some missing imports which were only available on `window` global object and therefore working correctly in the browser.
- In memory (javascript object) as alternative to missing `localStorage`

Note:
`function toLE()` moved from utils.js to types.js (to remove circular dependency) as it is needed in types.js, and utils.js depends on types.js