### PR TITLE
oo7-substrate: Improve / fix `addressBook` + `secretStore`

### DIFF
--- a/packages/oo7-substrate/src/addressBook.js
+++ b/packages/oo7-substrate/src/addressBook.js
@@ -5,7 +5,7 @@ const { AccountId } = require('./types')
 class AddressBook extends Bond {
 	constructor (storage) {
 		super()
-		this._storage = storage || typeof localStorage === 'undefined' ? {} : localStorage
+		this._storage = storage || (typeof localStorage === 'undefined' ? {} : localStorage)
 		this._accounts = []
 		this._load()
 	}

--- a/packages/oo7-substrate/src/secretStore.js
+++ b/packages/oo7-substrate/src/secretStore.js
@@ -19,7 +19,7 @@ function seedFromPhrase(phrase) {
 class SecretStore extends Bond {
 	constructor (storage) {
 		super()
-		this._storage = storage || typeof localStorage === 'undefined' ? {} : localStorage
+		this._storage = storage || (typeof localStorage === 'undefined' ? {} : localStorage)
 		this._keys = []
 		this._load()
 	}
@@ -38,6 +38,14 @@ class SecretStore extends Bond {
 		return this._keys.map(k => k.account)
 	}
 
+	byAddress (address) {
+		return this._keys.filter(k => k.address === address)[0]
+	}
+
+	byName (name) {
+		return this._keys.filter(k => k.name === name)[0]
+	}
+
 	find (identifier) {
 		if (this._keys.indexOf(identifier) !== -1) {
 			return identifier
@@ -45,7 +53,7 @@ class SecretStore extends Bond {
 		if (identifier instanceof Uint8Array && identifier.length == 32 || identifier instanceof AccountId) {
 			identifier = ss58Encode(identifier)
 		}
-		return this._byAddress[identifier] ? this._byAddress[identifier] : this._byName[identifier]
+		return this.byAddress(identifier) || this.byName(identifier)
 	}
 
 	sign (from, data) {
@@ -87,22 +95,15 @@ class SecretStore extends Bond {
 	}
 
 	_sync () {
-		let byAddress = {}
-		let byName = {}
 		this._keys = this._keys.map(({seed, phrase, name, key}) => {
 			seed = seed || seedFromPhrase(phrase)
 			key = key || nacl.sign.keyPair.fromSeed(seed)
 			let account = new AccountId(key.publicKey)
 			let address = ss58Encode(account)
-			let item = {seed, phrase, name, key, account, address}
-			byAddress[address] = item
-			byName[name] = item
-			return item
+			return {seed, phrase, name, key, account, address}
 		})
-		this._byAddress = byAddress
-		this._byName = byName
 		this._storage.secretStore = JSON.stringify(this._keys.map(k => ({seed: bytesToHex(k.seed), phrase: k.phrase, name: k.name})))
-		this.trigger({keys: this._keys, byAddress: this._byAddress, byName: this._byName})
+		this.trigger({keys: this._keys})
 	}
 }
 

--- a/packages/oo7-substrate/test/addressBook.js
+++ b/packages/oo7-substrate/test/addressBook.js
@@ -1,0 +1,44 @@
+require('chai').should()
+
+const { ss58Encode } = require('../src/ss58')
+const { addressBook } = require('../src/addressBook')
+
+describe('addressBook', () => {
+
+	const account = new Uint8Array([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0])
+	const name = "any-name"
+
+	beforeEach(function() {
+		// add an account
+		addressBook().submit(account, name)
+	});
+
+	afterEach(function() {
+		// clean up
+		addressBook().forget(account)
+	});
+
+
+	it('should remove an account by given address', () => {
+		addressBook().accounts().should.have.lengthOf(1)
+		addressBook().forget(account)
+		addressBook().accounts().should.have.lengthOf(0)
+	});
+
+	it('should not remove an account by given another address', () => {
+		const anotherAccount = new Uint8Array([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1])
+		addressBook().forget(anotherAccount);
+		addressBook().accounts().should.have.lengthOf(1)
+	});
+
+	it('find an account by name', () => {
+		addressBook().byName(name).should.have.property('account').equal(account)
+	});
+
+	it('find an account by address', () => {
+		const address = ss58Encode(account)
+		addressBook().submit(account, "my-name")
+		addressBook().byAddress(address).should.have.property('account').equal(account)
+	});
+
+});

--- a/packages/oo7-substrate/test/addressBook.js
+++ b/packages/oo7-substrate/test/addressBook.js
@@ -19,25 +19,25 @@ describe('addressBook', () => {
 	});
 
 
-	it('should remove an account by given address', () => {
-		addressBook().accounts().should.have.lengthOf(1)
+	it('should remove an account by an address', () => {
+		const length = addressBook().accounts().length
 		addressBook().forget(account)
-		addressBook().accounts().should.have.lengthOf(0)
+		addressBook().accounts().should.have.lengthOf(length - 1)
 	});
 
-	it('should not remove an account by given another address', () => {
+	it('should not remove an account using another address', () => {
+		const length = addressBook().accounts().length
 		const anotherAccount = new Uint8Array([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1])
 		addressBook().forget(anotherAccount);
-		addressBook().accounts().should.have.lengthOf(1)
+		addressBook().accounts().should.have.lengthOf(length)
 	});
 
-	it('find an account by name', () => {
+	it('should find an account by a name', () => {
 		addressBook().byName(name).should.have.property('account').equal(account)
 	});
 
-	it('find an account by address', () => {
+	it('should find an account by an address', () => {
 		const address = ss58Encode(account)
-		addressBook().submit(account, "my-name")
 		addressBook().byAddress(address).should.have.property('account').equal(account)
 	});
 

--- a/packages/oo7-substrate/test/secretStore.js
+++ b/packages/oo7-substrate/test/secretStore.js
@@ -1,0 +1,51 @@
+require('chai').should()
+
+const { ss58Encode } = require('../src/ss58')
+const { generateMnemonic } = require('bip39')
+const { secretStore } = require('../src/secretStore')
+
+describe('secretStore', () => {
+
+	var phrase = null
+	var account = null
+	const name = "any-name"
+
+	beforeEach(function() {
+		phrase = generateMnemonic()
+		account = secretStore().accountFromPhrase(phrase)
+		secretStore().submit(phrase, name)
+	});
+
+	afterEach(function() {
+		secretStore().forget(account)
+		account
+		= phrase
+		= null
+	});
+
+
+	it('should remove an account', () => {
+		const length = secretStore().accounts().length
+		const account = secretStore().accountFromPhrase(phrase)
+		secretStore().forget(account)
+		secretStore().accounts().should.have.lengthOf(length - 1)
+	});
+
+	it('can\'t remove an non-existing account', () => {
+		const length = secretStore().accounts().length
+		const anotherPhrase = generateMnemonic()
+		const anotherAccount = secretStore().accountFromPhrase(anotherPhrase)
+		secretStore().forget(anotherAccount)
+		secretStore().accounts().should.have.lengthOf(length)
+	});
+
+	it('should find an account by a name', () => {
+		secretStore().byName(name).should.have.property('name').equal(name)
+	});
+
+	it('should find an account by an address', () => {
+		const address = ss58Encode(account)
+		secretStore().byAddress(address).should.have.property('address').equal(address)
+	});
+
+});


### PR DESCRIPTION
*  [`addressBook + secretStore`] Provide helper functions `byAddress` and `byName` to avoid storing all (same) accounts at three different places in `this._accounts`, `this._byName` and `this._byAddress`. 
*  [`addressBook + secretStore`] Trigger changes by using `accounts` as a payload only, but not all (same) accounts in three different keys `{accounts, byAddress, byName}`. In case of getting accounts by its address and/or name, use new added functions `byAddress` and / or `byName`. 
* [`addressBook`] Fix missing import of `ss58Decode`
* [`addressBook`]  Option to set `storage` (similar to [`secretStore`](https://github.com/paritytech/oo7/blob/master/packages/oo7-substrate/src/secretStore.js))
* [`secretStore`]  Fix expression to get value of `this._storage`
* [`addressBook + secretStore`] Add tests