### PR TITLE
Only expose debugging methods on window object in browser

### DIFF
--- a/packages/oo7-substrate/src/secretStore.js
+++ b/packages/oo7-substrate/src/secretStore.js
@@ -116,22 +116,24 @@ function srKeypairFromUri(uri) {
 	return srCache[uri]
 }
 
-window.chainCodeFor = chainCodeFor
-window.deriveHardJunction = deriveHardJunction
-window.edSeedFromUri = edSeedFromUri
-window.pbkdf2Sync = pbkdf2Sync
-window.Buffer = Buffer
-window.mnemonicToEntropy = mnemonicToEntropy
-window.isReady = isReady
-window.waitReady = waitReady
-window.keypairFromSeed = keypairFromSeed
-window.sign = sign
-window.deriveKeypairHard = deriveKeypairHard
-window.derivePublicSoft = derivePublicSoft
-window.deriveKeypairSoft = deriveKeypairSoft
-window.srKeypairFromUri = srKeypairFromUri
-window.srKeypairToPublic = srKeypairToPublic
-window.wasmCrypto = wasmCrypto
+if (typeof window !== 'undefined') {
+	window.chainCodeFor = chainCodeFor
+	window.deriveHardJunction = deriveHardJunction
+	window.edSeedFromUri = edSeedFromUri
+	window.pbkdf2Sync = pbkdf2Sync
+	window.Buffer = Buffer
+	window.mnemonicToEntropy = mnemonicToEntropy
+	window.isReady = isReady
+	window.waitReady = waitReady
+	window.keypairFromSeed = keypairFromSeed
+	window.sign = sign
+	window.deriveKeypairHard = deriveKeypairHard
+	window.derivePublicSoft = derivePublicSoft
+	window.deriveKeypairSoft = deriveKeypairSoft
+	window.srKeypairFromUri = srKeypairFromUri
+	window.srKeypairToPublic = srKeypairToPublic
+	window.wasmCrypto = wasmCrypto
+}
 
 const ED25519 = 'ed25519'
 const SR25519 = 'sr25519'


### PR DESCRIPTION
If these methods are only used for testing / debugging in the web console perhaps we can put a conditional around them. Unless some are in-fact used globally or need to be exported on the secretStore module?

This fix will also make it possible to use oo7-substarte in cli 